### PR TITLE
Add another Marzipan type definitions

### DIFF
--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -104,8 +104,10 @@ export interface MarzipanInstance {
 }
 
 export interface MarzipanConstructor {
-  new (target: string | HTMLTextAreaElement | HTMLTextAreaElement[], options?: Options): [MarzipanInstance, ...MarzipanInstance[]];
-  init(target: string | HTMLTextAreaElement | HTMLTextAreaElement[], options?: Options): [MarzipanInstance, ...MarzipanInstance[]];
+  new (target: string | HTMLTextAreaElement, options?: Options): MarzipanInstance;
+  new (target: HTMLTextAreaElement[], options?: Options): MarzipanInstance[];
+  init(target: string | HTMLTextAreaElement, options?: Options): MarzipanInstance;
+  init(target: HTMLTextAreaElement[], options?: Options): MarzipanInstance[];
   getInstance(textarea: HTMLTextAreaElement): MarzipanInstance | undefined;
   destroyAll(): void;
   injectStyles(): void;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -42,8 +42,9 @@ export interface Stats {
 }
 
 export interface MobileOptions {
-  enabled: boolean;
-  breakpoint: number;
+  fontSize?: number;
+  padding?: number;
+  lineHeight?: number;
 }
 
 export interface ToolbarButtonConfig {

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -149,16 +149,48 @@ export interface Options {
 export interface MarzipanInstance {
   textarea: HTMLTextAreaElement | null;
   container: HTMLElement | null;
-  preview: HTMLElement | null;
-  options: Options;
+  textarea: HTMLTextAreaElement;
+  container: HTMLElement;
+  preview: HTMLElement;
+  /**
+   * The wrapper element that contains the editor UI.
+   */
+  wrapper: HTMLElement | null;
+  /**
+   * The statistics bar element, if enabled.
+   */
+  statsBar: HTMLElement | null;
+  /**
+   * The toolbar element, if enabled.
+   */
+  toolbar: HTMLElement | null;
+  /**
+   * The keyboard shortcuts helper element, if present.
+   */
+  shortcuts: HTMLElement | null;
+  /**
+   * The link tooltip element, if present.
+   */
+  linkTooltip: HTMLElement | null;
+  /**
+   * Whether this instance has completed initialization.
+   */
+  initialized: boolean;
+  /**
+   * A unique identifier for this Marzipan instance.
+   */
+  instanceId: string;
+  /**
+   * The underlying element this instance was created for.
+   */
+  element: HTMLElement;
+  options: Required<Options>;
   
   getValue(): string;
   setValue(value: string): void;
   getStats(): Stats;
-  getRenderedHTML(options?: RenderOptions): string;
-  getCleanHTML(): string;
-  getPreviewHTML(): string;
-  getContainer(): HTMLElement | null;
+  getHTML(): string;
+  getContainer(): HTMLElement;
   focus(): void;
   blur(): void;
   reinit(): void;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -1,28 +1,31 @@
 // Core Marzipan Types
 
 export interface ThemeColors {
-  bgPrimary: string;
-  bgSecondary: string;
-  text: string;
-  h1: string;
-  h2: string;
-  h3: string;
-  strong: string;
-  em: string;
-  link: string;
-  code: string;
-  codeBg: string;
-  blockquote: string;
-  hr: string;
-  syntaxMarker: string;
-  cursor: string;
-  selection: string;
-  listMarker: string;
-  toolbarBg: string;
-  toolbarBorder: string;
-  toolbarIcon: string;
-  toolbarHover: string;
-  toolbarActive: string;
+  bgPrimary?: string;
+  bgSecondary?: string;
+  text?: string;
+  textSecondary?: string;
+  h1?: string;
+  h2?: string;
+  h3?: string;
+  strong?: string;
+  em?: string;
+  link?: string;
+  code?: string;
+  codeBg?: string;
+  blockquote?: string;
+  hr?: string;
+  syntaxMarker?: string;
+  cursor?: string;
+  selection?: string;
+  listMarker?: string;
+  rawLine?: string;
+  border?: string;
+  toolbarBg?: string;
+  toolbarBorder?: string;
+  toolbarIcon?: string;
+  toolbarHover?: string;
+  toolbarActive?: string;
 }
 
 export interface Theme {

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -78,8 +78,7 @@ export interface Options {
   mobile?: MobileOptions;
   plugins?: MarzipanPlugin[];
   blockHandles?: boolean;
-  onChange?: (value: string) => void;
-  onKeydown?: (event: KeyboardEvent) => void;
+  hooks?: EditorHooks;
 }
 
 export interface MarzipanInstance {

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -5,52 +5,114 @@ export interface ThemeColors {
   bgSecondary?: string;
   text?: string;
   textSecondary?: string;
-  h1?: string;
-  h2?: string;
-  h3?: string;
-  strong?: string;
-  em?: string;
-  link?: string;
-  code?: string;
-  codeBg?: string;
-  blockquote?: string;
-  hr?: string;
-  syntaxMarker?: string;
-  cursor?: string;
-  selection?: string;
-  listMarker?: string;
-  rawLine?: string;
-  border?: string;
-  toolbarBg?: string;
-  toolbarBorder?: string;
-  toolbarIcon?: string;
-  toolbarHover?: string;
-  toolbarActive?: string;
+
+/**
+ * Color palette used to render the Marzipan editor UI and document content.
+ * All values are CSS color strings (e.g. hex, rgb, hsl, or named colors).
+ */
+export interface ThemeColors {
+  /** Background color for the main editor surface and primary containers. */
+  bgPrimary: string;
+  /** Background color for secondary surfaces such as sidebars and panels. */
+  bgSecondary: string;
+  /** Default text color for body content. */
+  text: string;
+  /** Text color for level‑1 headings. */
+  h1: string;
+  /** Text color for level‑2 headings. */
+  h2: string;
+  /** Text color for level‑3 headings. */
+  h3: string;
+  /** Text color for strong / bold text. */
+  strong: string;
+  /** Text color for emphasized / italic text. */
+  em: string;
+  /** Text color for hyperlinks. */
+  link: string;
+  /** Text color for inline code spans. */
+  code: string;
+  /** Background color for inline code and code blocks. */
+  codeBg: string;
+  /** Text color for blockquote content. */
+  blockquote: string;
+  /** Color used for horizontal rules. */
+  hr: string;
+  /** Color used for syntax highlight markers or decorations. */
+  syntaxMarker: string;
+  /** Color of the text cursor / caret. */
+  cursor: string;
+  /** Background color for the current text selection. */
+  selection: string;
+  /** Color used for list bullets or ordered list markers. */
+  listMarker: string;
+  /** Background color of the editor toolbar. */
+  toolbarBg: string;
+  /** Border color of the editor toolbar. */
+  toolbarBorder: string;
+  /** Default color for toolbar icons. */
+  toolbarIcon: string;
+  /** Color used when a toolbar item is hovered. */
+  toolbarHover: string;
+  /** Color used when a toolbar item is active or toggled on. */
+  toolbarActive: string;
 }
 
+/**
+ * A named visual theme that can be applied to the Marzipan editor.
+ */
 export interface Theme {
+  /** Human‑readable name of the theme (e.g. "Light", "Dark"). */
   name: string;
+  /** Color configuration used when this theme is active. */
   colors: ThemeColors;
 }
 
+/**
+ * Basic statistics about the current document content.
+ */
 export interface Stats {
+  /** Number of words in the document. */
   words: number;
-  chars: number;
+  /** Number of characters in the document, typically excluding formatting. */
+  characters: number;
+  /** Number of lines in the document. */
   lines: number;
-  line: number;
-  column: number;
 }
 
+/**
+ * Configuration options for adjusting the editor behavior on mobile devices.
+ */
 export interface MobileOptions {
-  fontSize?: number;
-  padding?: number;
-  lineHeight?: number;
+  /**
+   * Whether mobile‑specific behaviors and layout adjustments are enabled.
+   */
+  enabled: boolean;
+  /**
+   * Viewport width (in pixels) at which the editor should switch
+   * to its mobile layout or behavior.
+   */
+  breakpoint: number;
 }
 
+/**
+ * Configuration for an individual button in the editor toolbar.
+ */
 export interface ToolbarButtonConfig {
+  /**
+   * Identifier or command name for the action invoked when the button is clicked.
+   */
   action: string;
+  /**
+   * Optional icon identifier or CSS class for the toolbar button.
+   */
   icon?: string;
+  /**
+   * Optional title or tooltip text displayed for the button.
+   */
   title?: string;
+  /**
+   * When true, renders this entry as a visual separator instead of a button.
+   */
   separator?: boolean;
 }
 

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -158,7 +158,9 @@ export interface MarzipanInstance {
   getValue(): string;
   setValue(value: string): void;
   getStats(): Stats;
-  getHTML(): string;
+  getRenderedHTML(options?: RenderOptions): string;
+  getCleanHTML(): string;
+  getPreviewHTML(): string;
   getContainer(): HTMLElement | null;
   focus(): void;
   blur(): void;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -128,11 +128,7 @@ export interface RenderOptions {
   cleanHTML?: boolean;
 }
 
-export interface MarzipanPlugin {
-  name: string;
-  init: (editor: MarzipanInstance) => void;
-  destroy?: () => void;
-}
+export type MarzipanPlugin = (editor: MarzipanInstance) => void;
 
 export interface Options {
   theme?: string | Theme;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -110,10 +110,12 @@ export interface ToolbarButtonConfig {
    * Optional title or tooltip text displayed for the button.
    */
   title?: string;
-  /**
-   * When true, renders this entry as a visual separator instead of a button.
-   */
+  name?: keyof typeof icons | string;
+  action?: string;
+  icon?: string;
+  title?: string;
   separator?: boolean;
+  hasDropdown?: boolean;
 }
 
 export type ToolbarConfig = boolean | Array<string | ToolbarButtonConfig>;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -35,7 +35,7 @@ export interface Theme {
 
 export interface Stats {
   words: number;
-  characters: number;
+  chars: number;
   lines: number;
 }
 

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -37,6 +37,8 @@ export interface Stats {
   words: number;
   chars: number;
   lines: number;
+  line: number;
+  column: number;
 }
 
 export interface MobileOptions {

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -193,12 +193,11 @@ export interface MarzipanInstance {
   getContainer(): HTMLElement;
   focus(): void;
   blur(): void;
-  reinit(): void;
-  showStats(show?: boolean): boolean;
+  reinit(options?: Partial<Options>): void;
+  showStats(show: boolean): void;
   showPlainTextarea(show?: boolean): boolean;
-  showPreview(show?: boolean): boolean;
-  setupAutoResize(): void;
-  teardownAutoResize(): void;
+  showPreviewMode(show?: boolean): boolean;
+
   destroy(): void;
 }
 
@@ -207,7 +206,7 @@ export interface MarzipanConstructor {
   new (target: HTMLTextAreaElement[], options?: Options): MarzipanInstance[];
   init(target: string | HTMLTextAreaElement, options?: Options): MarzipanInstance;
   init(target: HTMLTextAreaElement[], options?: Options): MarzipanInstance[];
-  getInstance(textarea: HTMLTextAreaElement): MarzipanInstance | undefined;
+  getInstance(element: Element): MarzipanInstance | null;
   destroyAll(): void;
   injectStyles(): void;
   setTheme(theme: string | Theme, colors?: Partial<ThemeColors>): void;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -1,0 +1,114 @@
+// Core Marzipan Types
+
+export interface ThemeColors {
+  bgPrimary: string;
+  bgSecondary: string;
+  text: string;
+  h1: string;
+  h2: string;
+  h3: string;
+  strong: string;
+  em: string;
+  link: string;
+  code: string;
+  codeBg: string;
+  blockquote: string;
+  hr: string;
+  syntaxMarker: string;
+  cursor: string;
+  selection: string;
+  listMarker: string;
+  toolbarBg: string;
+  toolbarBorder: string;
+  toolbarIcon: string;
+  toolbarHover: string;
+  toolbarActive: string;
+}
+
+export interface Theme {
+  name: string;
+  colors: ThemeColors;
+}
+
+export interface Stats {
+  words: number;
+  characters: number;
+  lines: number;
+}
+
+export interface MobileOptions {
+  enabled: boolean;
+  breakpoint: number;
+}
+
+export interface ToolbarButtonConfig {
+  action: string;
+  icon?: string;
+  title?: string;
+  separator?: boolean;
+}
+
+export type ToolbarConfig = boolean | Array<string | ToolbarButtonConfig>;
+
+export interface EditorHooks {
+  onChange?: (value: string) => void;
+  onKeydown?: (event: KeyboardEvent) => void;
+}
+
+export interface RenderOptions {
+  preserveScroll?: boolean;
+}
+
+export interface MarzipanPlugin {
+  name: string;
+  init: (editor: MarzipanInstance) => void;
+  destroy?: () => void;
+}
+
+export interface Options {
+  theme?: string | Theme;
+  colors?: Partial<ThemeColors>;
+  toolbar?: ToolbarConfig;
+  placeholder?: string;
+  smartLists?: boolean;
+  autoResize?: boolean;
+  showStats?: boolean;
+  statsFormatter?: (stats: Stats) => string;
+  preview?: 'overlay' | 'plain' | 'preview-only';
+  mobile?: MobileOptions;
+  plugins?: MarzipanPlugin[];
+  blockHandles?: boolean;
+  onChange?: (value: string) => void;
+  onKeydown?: (event: KeyboardEvent) => void;
+}
+
+export interface MarzipanInstance {
+  textarea: HTMLTextAreaElement | null;
+  container: HTMLElement | null;
+  preview: HTMLElement | null;
+  options: Required<Options>;
+  
+  getValue(): string;
+  setValue(value: string): void;
+  getStats(): Stats;
+  getHTML(): string;
+  getContainer(): HTMLElement | null;
+  focus(): void;
+  blur(): void;
+  reinit(): void;
+  showStats(show?: boolean): boolean;
+  showPlainTextarea(show?: boolean): boolean;
+  showPreview(show?: boolean): boolean;
+  setupAutoResize(): void;
+  teardownAutoResize(): void;
+  destroy(): void;
+}
+
+export interface MarzipanConstructor {
+  new (target: string | HTMLTextAreaElement | HTMLTextAreaElement[], options?: Options): [MarzipanInstance, ...MarzipanInstance[]];
+  init(target: string | HTMLTextAreaElement | HTMLTextAreaElement[], options?: Options): [MarzipanInstance, ...MarzipanInstance[]];
+  getInstance(textarea: HTMLTextAreaElement): MarzipanInstance | undefined;
+  destroyAll(): void;
+  injectStyles(): void;
+  setTheme(theme: string | Theme, colors?: Partial<ThemeColors>): void;
+}

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -86,7 +86,7 @@ export interface MarzipanInstance {
   textarea: HTMLTextAreaElement | null;
   container: HTMLElement | null;
   preview: HTMLElement | null;
-  options: Required<Options>;
+  options: Options;
   
   getValue(): string;
   setValue(value: string): void;

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -121,8 +121,7 @@ export interface ToolbarButtonConfig {
 export type ToolbarConfig = boolean | Array<string | ToolbarButtonConfig>;
 
 export interface EditorHooks {
-  onChange?: (value: string) => void;
-  onKeydown?: (event: KeyboardEvent) => void;
+  afterPreviewRender?: (root: HTMLElement, instance: MarzipanInstance) => void;
 }
 
 export interface RenderOptions {

--- a/src/marzipan.d.ts.new
+++ b/src/marzipan.d.ts.new
@@ -125,7 +125,7 @@ export interface EditorHooks {
 }
 
 export interface RenderOptions {
-  preserveScroll?: boolean;
+  cleanHTML?: boolean;
 }
 
 export interface MarzipanPlugin {


### PR DESCRIPTION
Comparison needed to compare this new file (marzipan.d.ts.new) to the original marzipan.d.ts to see what is new and what type definitions etc might need to be added to the original types file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds comprehensive TypeScript type definitions for the Marzipan editor public API: theming, stats, mobile/responsive options, toolbar customization, editor hooks, render options, plugin support, and instance lifecycle/management utilities.

* **Documentation**
  * Formalizes the editor API surface with typed interfaces to improve IDE assistance, configuration clarity, and developer experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->